### PR TITLE
Refactor descriptor set interface

### DIFF
--- a/.clang_complete
+++ b/.clang_complete
@@ -6,4 +6,5 @@
 -I/Users/sam/Documents/code/gfx/Fever/src/libs/stb_image
 -I/Users/sam/Documents/code/gfx/Fever/src/libs/tiny_obj
 -isystem/usr/local/include
+-std=gnu++11
 -std=gnu++14

--- a/src/FeverLibrary/CMakeLists.txt
+++ b/src/FeverLibrary/CMakeLists.txt
@@ -18,6 +18,8 @@ target_include_directories(Fever
 
 set_property(TARGET Fever PROPERTY C_STANDARD_REQUIRED ON)
 set_property(TARGET Fever PROPERTY C_STANDARD 99)
+set_property(TARGET Fever PROPERTY CXX_STANDARD_REQUIRED ON)
+set_property(TARGET Fever PROPERTY CXX_STANDARD 11)
 
 # target_compile_features(Fever
 #   )

--- a/src/FeverLibrary/include/Fever/Fever.h
+++ b/src/FeverLibrary/include/Fever/Fever.h
@@ -366,86 +366,101 @@ typedef struct FvPipelineVertexInputDescription {
     const FvVertexInputAttributeDescription *vertexAttributeDescriptions;
 } FvPipelineVertexInputDescription;
 
-FV_DEFINE_HANDLE(FvDescriptorSetLayout);
+FV_DEFINE_HANDLE(FvDescriptorSet);
 
-/** Descriptor set layout binding information */
-typedef struct FvDescriptorSetLayoutBinding {
-    /** Binding point. */
+/**
+ * Information about a descriptor (a shader uniform). This information is used
+ * to create a descriptor set, which is an aggregrate of one or more
+ * descriptors. The graphics pipeline only accepts descriptor sets as bindings.
+*/
+typedef struct FvDescriptorInfo {
+    /**
+     * Binding point in the shader - use the shader reflection system to get
+     * this.
+     */
     uint32_t binding;
     /** Type of the descriptor. */
     FvDescriptorType descriptorType;
-    /** Number of descriptors contained in the binding, this appears as an array
-     * in the shader. */
-    uint32_t descriptorCount;
-    /** Bitmask specifying which stages of the shader pipeline can use the
-     * resource(s) attached to this binding. */
-    FvShaderStage stageFlags;
-} FvDescriptorSetLayoutBinding;
-
-typedef struct FvDescriptorSetLayoutCreateInfo {
-    /** Number of elements in \p bindings. */
-    uint32_t bindingCount;
-    /** Array of descriptor set layout binding structures. */
-    const FvDescriptorSetLayoutBinding *bindings;
-} FvDescriptorSetLayoutCreateInfo;
-
-extern FvResult
-fvDescriptorSetLayoutCreate(FvDescriptorSetLayout *descriptorSetLayout,
-                            const FvDescriptorSetLayoutCreateInfo *createInfo);
-
-extern void
-fvDescriptorSetLayoutDestroy(FvDescriptorSetLayout descriptorSetLayout);
-
-FV_DEFINE_HANDLE(FvDescriptorPool);
-
-/** Structure to specify the number of descriptor sets that can be contained
- * within a descriptor pool. */
-typedef struct FvDescriptorPoolSize {
-    /** Type of the descriptor. */
-    FvDescriptorType descriptorType;
-    /** Number of descriptors to allocate memory for. */
-    uint32_t descriptorCount;
-} FvDescriptorPoolSize;
-
-/** Structure to define the properties of a new descriptor pool. */
-typedef struct FvDescriptorPoolCreateInfo {
-    /** Maximum number of descriptor sets that can be allocated from the pool.
+    /**
+     * Number of descriptors contained in the binding, this appears as an array
+     * in the shader. You can just set this to 1 if your shader uniform is not
+     * an array.
      */
-    uint32_t maxSets;
-    /** Number of elements in \p poolSizes array. */
-    uint32_t poolSizeCount;
-    /** Array of structures describing size of each pool. */
-    const FvDescriptorPoolSize *poolSizes;
-} FvDescriptorPoolCreateInfo;
-
-extern FvResult
-fvDescriptorPoolCreate(FvDescriptorPool *descriptorPool,
-                       const FvDescriptorPoolCreateInfo *createInfo);
-
-extern void fvDescriptorPoolDestroy(FvDescriptorPool descriptorPool);
-
-FV_DEFINE_HANDLE(FvDescriptorSet);
-
-/** Structure used to create and allocate space for descriptor sets. */
-typedef struct FvDescriptorSetAllocateInfo {
-    /** Descriptor pool to allocate descriptor sets from. */
-    FvDescriptorPool descriptorPool;
-    /** Number of descriptor sets in \p setLayouts array. */
-    uint32_t descriptorSetCount;
-    /** Array of descriptor set layouts to allocate memory for. */
-    FvDescriptorSetLayout *setLayouts;
-} FvDescriptorSetAllocatInfo;
+    uint32_t descriptorCount;
+    /**
+     * Bitmask specifying which stages of the shader pipeline this descriptor
+     * will be bound to.
+     */
+    FvShaderStage stageFlags;
+} FvDescriptorInfo;
 
 /**
- * Allocate one to many descriptor sets.
- *
- * \param allocateInfo Information used to properly allocate descriptor sets.
- * \param [out] descriptorSets Allocated descriptor sets ready to write to.
- * \return FV_RESULT_SUCCESS on success, FV_RESULT_FAILURE on failure.
+ * Information used to create a descriptor set, which is just a collection of
+ * individual descriptors.
  */
+typedef struct FvDescriptorSetCreateInfo {
+    /** Number of elements in \p descriptors. */
+    uint32_t descriptorCount;
+    /**
+     * Array of descriptors to create and associate with this descriptor set.
+     */
+    const FvDescriptorInfo *descriptors;
+} FvDescriptorSetCreateInfo;
+
 extern FvResult
-fvAllocateDescriptorSets(FvDescriptorSet *descriptorSets,
-                         const FvDescriptorSetAllocateInfo *allocateInfo);
+fvDescriptorSetCreate(FvDescriptorSet *descriptorSet,
+                      const FvDescriptorSetCreateInfo *createInfo);
+
+extern void fvDescriptorSetDestroy(FvDescriptorSet descriptorSet);
+
+/* FV_DEFINE_HANDLE(FvDescriptorPool); */
+
+/* /\** Structure to specify the number of descriptor sets that can be contained */
+/*  * within a descriptor pool. *\/ */
+/* typedef struct FvDescriptorPoolSize { */
+/*     /\** Type of the descriptor. *\/ */
+/*     FvDescriptorType descriptorType; */
+/*     /\** Number of descriptors to allocate memory for. *\/ */
+/*     uint32_t descriptorCount; */
+/* } FvDescriptorPoolSize; */
+
+/* /\** Structure to define the properties of a new descriptor pool. *\/ */
+/* typedef struct FvDescriptorPoolCreateInfo { */
+/*     /\** Maximum number of descriptor sets that can be allocated from the pool. */
+/*      *\/ */
+/*     uint32_t maxSets; */
+/*     /\** Number of elements in \p poolSizes array. *\/ */
+/*     uint32_t poolSizeCount; */
+/*     /\** Array of structures describing size of each pool. *\/ */
+/*     const FvDescriptorPoolSize *poolSizes; */
+/* } FvDescriptorPoolCreateInfo; */
+
+/* extern FvResult */
+/* fvDescriptorPoolCreate(FvDescriptorPool *descriptorPool, */
+/*                        const FvDescriptorPoolCreateInfo *createInfo); */
+
+/* extern void fvDescriptorPoolDestroy(FvDescriptorPool descriptorPool); */
+
+/* /\** Structure used to create and allocate space for descriptor sets. *\/ */
+/* typedef struct FvDescriptorSetAllocateInfo { */
+/*     /\** Descriptor pool to allocate descriptor sets from. *\/ */
+/*     FvDescriptorPool descriptorPool; */
+/*     /\** Number of descriptor sets in \p setLayouts array. *\/ */
+/*     uint32_t descriptorSetCount; */
+/*     /\** Array of descriptor set layouts to allocate memory for. *\/ */
+/*     FvDescriptorSetLayout *setLayouts; */
+/* } FvDescriptorSetAllocatInfo; */
+
+/* /\** */
+/*  * Allocate one to many descriptor sets. */
+/*  * */
+/*  * \param allocateInfo Information used to properly allocate descriptor sets. */
+/*  * \param [out] descriptorSets Allocated descriptor sets ready to write to. */
+/*  * \return FV_RESULT_SUCCESS on success, FV_RESULT_FAILURE on failure. */
+/*  *\/ */
+/* extern FvResult */
+/* fvAllocateDescriptorSets(FvDescriptorSet *descriptorSets, */
+/*                          const FvDescriptorSetAllocateInfo *allocateInfo); */
 
 /** Information about the buffer tied to a descriptor set. */
 typedef struct FvDescriptorBufferInfo {
@@ -489,7 +504,11 @@ typedef struct FvWriteDescriptorSet {
     const FvDescriptorImageInfo *imageInfo;
 } FvWriteDescriptorSet;
 
-/** Update the contents of one to many descriptor sets. */
+/**
+ * Update the contents of one to many descriptor sets. If any particular write
+ * fails for any reason, this function will simply skip that write and fulfill
+ * as many of the other write requests as it can.
+ */
 extern void
 fvUpdateDescriptorSets(uint32_t descriptorWriteCount,
                        const FvWriteDescriptorSet *descriptorWrites);
@@ -506,12 +525,12 @@ typedef struct FvPushConstantRange {
 } FvPushConstantRange;
 
 /** Used to specify uniform values in shader. Describes complete set of
-    resources that can be accessed by a pipline. */
+    resources that can be accessed by a pipeline. */
 typedef struct FvPipelineLayoutCreateInfo {
-    /** Number of set layouts */
-    uint32_t setLayoutCount;
-    /** Array of descriptor set layouts */
-    FvDescriptorSetLayout *setLayouts;
+    /** Number of descriptor sets in \p descriptor sets array */
+    uint32_t descriptorSetCount;
+    /** Array of descriptor sets */
+    FvDescriptorSet *descriptorSets;
     /** Number of push constant ranges */
     uint32_t pushConstantRangeCount;
     /** Array of push constant ranges */

--- a/src/FeverLibrary/src/FeverMetalBackend.mm
+++ b/src/FeverLibrary/src/FeverMetalBackend.mm
@@ -44,33 +44,6 @@ void fvShutdown() {
     }
 }
 
-FvResult fvDescriptorPoolCreate(FvDescriptorPool *descriptorPool,
-                                const FvDescriptorPoolCreateInfo *createInfo) {
-    if (metalWrapper != nullptr) {
-        return metalWrapper->descriptorPoolCreate(descriptorPool, createInfo);
-    } else {
-        return FV_RESULT_FAILURE;
-    }
-}
-
-void fvDescriptorPoolDestroy(FvDescriptorPool descriptorPool) {
-    assert(metalWrapper != nullptr);
-    if (metalWrapper != nullptr) {
-        metalWrapper->descriptorPoolDestroy(descriptorPool);
-    }
-}
-
-FvResult
-fvAllocateDescriptorSets(FvDescriptorSet *descriptorSets,
-                         const FvDescriptorSetAllocateInfo *allocateInfo) {
-    if (metalWrapper != nullptr) {
-        return metalWrapper->allocateDescriptorSets(descriptorSets,
-                                                    allocateInfo);
-    } else {
-        return FV_RESULT_FAILURE;
-    }
-}
-
 void fvUpdateDescriptorSets(uint32_t descriptorWriteCount,
                             const FvWriteDescriptorSet *descriptorWrites) {
     if (metalWrapper != nullptr) {
@@ -446,20 +419,18 @@ void fvCmdDrawIndexed(FvCommandBuffer commandBuffer, uint32_t indexCount,
     }
 }
 
-FvResult
-fvDescriptorSetLayoutCreate(FvDescriptorSetLayout *descriptorSetLayout,
-                            const FvDescriptorSetLayoutCreateInfo *createInfo) {
+FvResult fvDescriptorSetCreate(FvDescriptorSet *descriptorSet,
+                               const FvDescriptorSetCreateInfo *createInfo) {
     if (metalWrapper != nullptr) {
-        return metalWrapper->descriptorSetLayoutCreate(descriptorSetLayout,
-                                                       createInfo);
+        return metalWrapper->descriptorSetCreate(descriptorSet, createInfo);
     } else {
         return FV_RESULT_FAILURE;
     }
 }
 
-void fvDescriptorSetLayoutDestroy(FvDescriptorSetLayout descriptorSetLayout) {
+void fvDescriptorSetDestroy(FvDescriptorSet descriptorSet) {
     assert(metalWrapper != nullptr);
     if (metalWrapper != nullptr) {
-        metalWrapper->descriptorSetLayoutDestroy(descriptorSetLayout);
+        metalWrapper->descriptorSetDestroy(descriptorSet);
     }
 }

--- a/src/projects/app/src/app.cpp
+++ b/src/projects/app/src/app.cpp
@@ -172,7 +172,7 @@ class HelloTriangleApplication {
     void initFever() {
         createSwapchain();
         createRenderPass();
-        createDescriptorSetLayout();
+        createDescriptorSet();
         createGraphicsPipeline();
         createCommandPool();
         createDepthResources();
@@ -183,8 +183,7 @@ class HelloTriangleApplication {
         createVertexBuffer();
         createIndexBuffer();
         createUniformBuffer();
-        createDescriptorPool();
-        createDescriptorSet();
+        writeDescriptorSet();
         createCommandBuffer();
         createSemaphores();
     }
@@ -348,6 +347,36 @@ class HelloTriangleApplication {
             throw std::runtime_error("Failed to create vertex buffer!");
         }
     }
+    
+    void writeDescriptorSet() {
+        FvDescriptorBufferInfo bufferInfo = {};
+        bufferInfo.buffer                 = uniformBuffer;
+        bufferInfo.offset                 = 0;
+        bufferInfo.range                  = sizeof(UniformBufferObject);
+        
+        FvDescriptorImageInfo imageInfo = {};
+        imageInfo.image                 = textureImage;
+        imageInfo.sampler               = textureSampler;
+        
+        std::array<FvWriteDescriptorSet, 2> descriptorWrites = {};
+        descriptorWrites[0].dstSet          = descriptorSet;
+        descriptorWrites[0].dstBinding      = 1;
+        descriptorWrites[0].dstArrayElement = 0;
+        descriptorWrites[0].descriptorType  = FV_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+        descriptorWrites[0].descriptorCount = 1;
+        descriptorWrites[0].bufferInfo      = &bufferInfo;
+        
+        descriptorWrites[1].dstSet          = descriptorSet;
+        descriptorWrites[1].dstBinding      = 0;
+        descriptorWrites[1].dstArrayElement = 0;
+        descriptorWrites[1].descriptorType =
+        FV_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+        descriptorWrites[1].descriptorCount = 1;
+        descriptorWrites[1].imageInfo       = &imageInfo;
+        
+        fvUpdateDescriptorSets(descriptorWrites.size(),
+                               descriptorWrites.data());
+    }
 
     void updateUniformBuffer() {
         static auto startTime = std::chrono::high_resolution_clock::now();
@@ -508,89 +537,68 @@ class HelloTriangleApplication {
     }
 
     void createDescriptorSetLayout() {
-        FvDescriptorSetLayoutBinding uboLayoutBinding = {};
-        uboLayoutBinding.binding                      = 1;
-        uboLayoutBinding.descriptorType  = FV_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
-        uboLayoutBinding.descriptorCount = 1;
-        uboLayoutBinding.stageFlags      = FV_SHADER_STAGE_VERTEX;
-
-        FvDescriptorSetLayoutBinding samplerLayoutBinding = {};
-        samplerLayoutBinding.binding                      = 0;
-        samplerLayoutBinding.descriptorCount              = 1;
-        samplerLayoutBinding.descriptorType =
-            FV_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-        samplerLayoutBinding.stageFlags = FV_SHADER_STAGE_FRAGMENT;
-
-        std::array<FvDescriptorSetLayoutBinding, 2> bindings = {
-            uboLayoutBinding, samplerLayoutBinding};
-
-        FvDescriptorSetLayoutCreateInfo layoutInfo = {};
-        layoutInfo.bindingCount                    = bindings.size();
-        layoutInfo.bindings                        = bindings.data();
-
-        if (fvDescriptorSetLayoutCreate(descriptorSetLayout.replace(),
-                                        &layoutInfo) != FV_RESULT_SUCCESS) {
-            throw std::runtime_error("Failed to create descriptor set layout!");
-        }
-    }
+           }
 
     void createDescriptorPool() {
-        std::array<FvDescriptorPoolSize, 2> poolSizes = {};
-        poolSizes[0].descriptorType  = FV_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
-        poolSizes[0].descriptorCount = 1;
-        poolSizes[1].descriptorType = FV_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-        poolSizes[1].descriptorCount = 1;
+        // std::array<FvDescriptorPoolSize, 2> poolSizes = {};
+        // poolSizes[0].descriptorType  = FV_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+        // poolSizes[0].descriptorCount = 1;
+        // poolSizes[1].descriptorType =
+        // FV_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+        // poolSizes[1].descriptorCount = 1;
 
-        FvDescriptorPoolCreateInfo poolInfo = {};
-        poolInfo.poolSizeCount              = poolSizes.size();
-        poolInfo.poolSizes                  = poolSizes.data();
-        poolInfo.maxSets                    = 1;
+        // FvDescriptorPoolCreateInfo poolInfo = {};
+        // poolInfo.poolSizeCount              = poolSizes.size();
+        // poolInfo.poolSizes                  = poolSizes.data();
+        // poolInfo.maxSets                    = 1;
 
-        if (fvDescriptorPoolCreate(descriptorPool.replace(), &poolInfo) !=
-            FV_RESULT_SUCCESS) {
-            throw std::runtime_error("Failed to create descriptor pool!");
-        }
+        // if (fvDescriptorPoolCreate(descriptorPool.replace(), &poolInfo) !=
+        //     FV_RESULT_SUCCESS) {
+        //     throw std::runtime_error("Failed to create descriptor pool!");
+        // }
     }
 
     void createDescriptorSet() {
-        FvDescriptorSetLayout layouts[]       = {descriptorSetLayout};
-        FvDescriptorSetAllocateInfo allocInfo = {};
-        allocInfo.descriptorPool              = descriptorPool;
-        allocInfo.descriptorSetCount          = 1;
-        allocInfo.setLayouts                  = layouts;
+        // FvDescriptorSetLayout layouts[]       = {descriptorSetLayout};
+        // FvDescriptorSetAllocateInfo allocInfo = {};
+        // allocInfo.descriptorPool              = descriptorPool;
+        // allocInfo.descriptorSetCount          = 1;
+        // allocInfo.setLayouts                  = layouts;
 
-        if (fvAllocateDescriptorSets(&descriptorSet, &allocInfo) !=
-            FV_RESULT_SUCCESS) {
-            throw std::runtime_error("Failed to allocate descriptor set!");
+        // if (fvAllocateDescriptorSets(&descriptorSet, &allocInfo) !=
+        //     FV_RESULT_SUCCESS) {
+        //     throw std::runtime_error("Failed to allocate descriptor set!");
+        // }
+        FvDescriptorInfo uboLayoutBinding = {};
+        uboLayoutBinding.binding          = 1;
+        uboLayoutBinding.descriptorType   = FV_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+        uboLayoutBinding.descriptorCount  = 1;
+        uboLayoutBinding.stageFlags       = FV_SHADER_STAGE_VERTEX;
+        
+        FvDescriptorInfo samplerLayoutBinding = {};
+        samplerLayoutBinding.binding          = 0;
+        samplerLayoutBinding.descriptorCount  = 1;
+        samplerLayoutBinding.descriptorType =
+        FV_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+        samplerLayoutBinding.stageFlags = FV_SHADER_STAGE_FRAGMENT;
+        
+        std::array<FvDescriptorInfo, 2> descriptors = {uboLayoutBinding,
+            samplerLayoutBinding};
+        
+        FvDescriptorSetCreateInfo descriptorSetInfo = {};
+        descriptorSetInfo.descriptorCount           = descriptors.size();
+        descriptorSetInfo.descriptors               = descriptors.data();
+        
+        // if (fvDescriptorSetLayoutCreate(descriptorSetLayout.replace(),
+        //                                 &layoutInfo) != FV_RESULT_SUCCESS) {
+        //     throw std::runtime_error("Failed to create descriptor set
+        //     layout!");
+        // }
+        
+        if (fvDescriptorSetCreate(descriptorSet.replace(),
+                                  &descriptorSetInfo) != FV_RESULT_SUCCESS) {
+            throw std::runtime_error("Failed to create descriptor set");
         }
-
-        FvDescriptorBufferInfo bufferInfo = {};
-        bufferInfo.buffer                 = uniformBuffer;
-        bufferInfo.offset                 = 0;
-        bufferInfo.range                  = sizeof(UniformBufferObject);
-
-        FvDescriptorImageInfo imageInfo = {};
-        imageInfo.image                 = textureImage;
-        imageInfo.sampler               = textureSampler;
-
-        std::array<FvWriteDescriptorSet, 2> descriptorWrites = {};
-        descriptorWrites[0].dstSet          = descriptorSet;
-        descriptorWrites[0].dstBinding      = 1;
-        descriptorWrites[0].dstArrayElement = 0;
-        descriptorWrites[0].descriptorType  = FV_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
-        descriptorWrites[0].descriptorCount = 1;
-        descriptorWrites[0].bufferInfo      = &bufferInfo;
-
-        descriptorWrites[1].dstSet          = descriptorSet;
-        descriptorWrites[1].dstBinding      = 0;
-        descriptorWrites[1].dstArrayElement = 0;
-        descriptorWrites[1].descriptorType =
-            FV_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-        descriptorWrites[1].descriptorCount = 1;
-        descriptorWrites[1].imageInfo       = &imageInfo;
-
-        fvUpdateDescriptorSets(descriptorWrites.size(),
-                               descriptorWrites.data());
     }
 
     void createGraphicsPipeline() {
@@ -678,11 +686,12 @@ class HelloTriangleApplication {
         colorBlending.attachmentCount                      = 1;
         colorBlending.attachments = &colorBlendAttachment;
 
-        FvDescriptorSetLayout setLayouts[]            = {descriptorSetLayout};
+        FvDescriptorSet descriptorSets[]              = {descriptorSet};
         FvPipelineLayoutCreateInfo pipelineLayoutInfo = {};
-        pipelineLayoutInfo.setLayoutCount             = 1;
-        pipelineLayoutInfo.setLayouts                 = setLayouts;
+        pipelineLayoutInfo.descriptorSetCount         = 1;
+        pipelineLayoutInfo.descriptorSets             = descriptorSets;
         pipelineLayoutInfo.pushConstantRangeCount     = 0;
+        pipelineLayoutInfo.pushConstantRanges         = nullptr;
 
         if (fvPipelineLayoutCreate(pipelineLayout.replace(),
                                    &pipelineLayoutInfo) != FV_RESULT_SUCCESS) {
@@ -851,11 +860,8 @@ class HelloTriangleApplication {
     FDeleter<FvBuffer> vertexBuffer{fvBufferDestroy};
     FDeleter<FvBuffer> indexBuffer{fvBufferDestroy};
 
-    FDeleter<FvDescriptorSetLayout> descriptorSetLayout{
-        fvDescriptorSetLayoutDestroy};
     FDeleter<FvBuffer> uniformBuffer{fvBufferDestroy};
-    FDeleter<FvDescriptorPool> descriptorPool{fvDescriptorPoolDestroy};
-    FvDescriptorSet descriptorSet;
+    FDeleter<FvDescriptorSet> descriptorSet{fvDescriptorSetDestroy};
     FDeleter<FvImage> textureImage{fvImageDestroy};
     FDeleter<FvSampler> textureSampler{fvSamplerDestroy};
     FDeleter<FvImage> depthImage{fvImageDestroy};
@@ -864,22 +870,22 @@ class HelloTriangleApplication {
 int main(void) {
     // Initialize SDL2
     SDL_Init(SDL_INIT_VIDEO);
-    
+
     uint32_t flags = 0x0;
     flags |= SDL_WINDOW_RESIZABLE;
-    
+
     // Create window
     SDL_Window *window =
-    SDL_CreateWindow("Test bed", SDL_WINDOWPOS_CENTERED,
-                     SDL_WINDOWPOS_CENTERED, 800, 600, flags);
-    
+        SDL_CreateWindow("Test bed", SDL_WINDOWPOS_CENTERED,
+                         SDL_WINDOWPOS_CENTERED, 800, 600, flags);
+
     try {
         if (window == nullptr) {
             std::stringstream err;
             err << "Could not create window: " << SDL_GetError();
             throw std::runtime_error(err.str());
         }
-        
+
         // Create surface
         FDeleter<FvSurface> surface{fvDestroySurface};
 
@@ -906,7 +912,7 @@ int main(void) {
         if (fvInit(&initInfo) != FV_RESULT_SUCCESS) {
             throw std::runtime_error("Failed to initialize Fever library.");
         }
-        
+
         HelloTriangleApplication app(window);
 
         app.run();
@@ -915,9 +921,9 @@ int main(void) {
         std::cerr << err.what() << std::endl;
         return EXIT_FAILURE;
     }
-    
+
     fvShutdown();
-    
+
     SDL_DestroyWindow(window);
     SDL_Quit();
 


### PR DESCRIPTION
- Refactored descriptor set interface. Descriptor sets and the descriptor set
  writing interface remains the same, but the concept of descriptor set layouts
  and descriptor pools is gone. I feel these made the API unnecessarily complex
  and can be handled behind the scenes in the case of Vulkan (to be proven).